### PR TITLE
Allow retrieve labels to accept an authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,10 @@ Install development requirements
 ```$ pip install . --group dev```
 
 Run tests with pytest  
-```$ python -m pytest```  
+```$ python -m pytest --cov --cov-report=html:calc_cov```  
+
+Run tests and produce HTML coverage report
+```$ python -m pytest 
 
 ## Build documentation
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,7 +24,6 @@ templates_path = ['_templates']
 exclude_patterns = []
 
 
-
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "loc-authorities"
-version = "0.1.0"
+version = "0.2.0"
 description = "Python module for interacting with Library of Congress Linked Data Service and API endpoint"
 authors = [
     {name = "Center for Digital Scholarship at the American Philosophical Society", email = "cds@amphilsoc.org"},

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -136,12 +136,41 @@ class LocAPI(object):
 
         return []
 
-    def retrieve_label(self, label):
+    def retrieve_label(self, label, authority=None):
         """Query LoC's label retrieval API to return a URI from
-        a known label"""
+        a known label
+
+        :param label: The label to retrieve (string)
+        :param authority: the name of the authority to query. Defaults to `None`
+        """
 
         # TODO: Allow authorities to be passed in query
-        base_url = 'https://id.loc.gov/authorities/label/'
+        accepted_authorities = [
+            'subjects',
+            'childrensSubjects',
+            'performanceMediums',
+            'demographicTerms',
+            'graphicMaterials',
+            'ethnographicTerms',
+            'names',
+            'genreForms',
+        ]
+        if authority is None:
+            base_url = 'https://id.loc.gov/authorities/label/'
+        else:
+            if authority in accepted_authorities:
+                base_url = f'https://id.loc.gov/authorities/{authority}/label/'
+            else:
+                raise ValueError("""The authority supplied is not accepted. Please choose:
+                - subjects
+                - childrensSubjects
+                - performanceMediums
+                - demographicTerms
+                - graphicMaterials
+                - ethnographicTerms
+                - names
+                - genreForms
+                """)
         query_url = urljoin(base_url, label)
         response = requests.get(query_url, allow_redirects=False)
         # successful query should return a redirect
@@ -188,7 +217,9 @@ class LocEntity(object):
         graph = rdflib.Graph()
         # try to query dataset URI first if it exists - sometimes plain URI throws an error
         if self.dataset_uri:
-            response = requests.get(self.dataset_uri, headers={'Accept': 'application/rdf+xml'})
+            response = requests.get(
+                self.dataset_uri, headers={'Accept': 'application/rdf+xml'}
+            )
         else:
             response = requests.get(self.uri, headers={'Accept': 'application/rdf+xml'})
         response.raise_for_status()  # raise HTTPError on bad requests

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -180,7 +180,6 @@ class LocAPI(object):
             return identifier
 
         else:
-            # TODO: Not covered by test suite. Implement test
             response.raise_for_status()
 
             return None

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -179,9 +179,10 @@ class LocAPI(object):
             identifier = uri.split('/')[-1]
             return identifier
 
+        elif response.status_code == 404:
+            logger.warning(f'404 returned for {label}.')
+            return None
         else:
-            response.raise_for_status()
-
             return None
 
 

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -183,6 +183,8 @@ class LocAPI(object):
             # TODO: Not covered by test suite. Implement test
             response.raise_for_status()
 
+            return None
+
 
 # Question: Does each dataset need its own representation?
 class LocEntity(object):
@@ -221,6 +223,7 @@ class LocEntity(object):
                 self.dataset_uri, headers={'Accept': 'application/rdf+xml'}
             )
         else:
+            # not covered by test suite
             response = requests.get(self.uri, headers={'Accept': 'application/rdf+xml'})
         response.raise_for_status()  # raise HTTPError on bad requests
         graph.parse(data=response.text, format='xml')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -112,6 +112,9 @@ class TestLocAPI(object):
         mock_response.status_code = 404
         assert loc.retrieve_label('History of science', authority='subjects') is None
 
+        mock_response.status_code = 500
+        assert loc.retrieve_label('History of science', authority='subjects') is None
+
     # features to test for search results:
     # constructs URLs correctly for differing authorities
     # returns empty list with no results

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,6 +100,15 @@ class TestLocAPI(object):
 
         assert loc.retrieve_label('Franklin, Benjamin, 1706-1790') == 'n79043402'
 
+        loc.retrieve_label('Franklin, Benjamin, 1706-1790', authority="names")
+        mockrequests.get.assert_called_with('https://id.loc.gov/authorities/names/label/Franklin, Benjamin, 1706-1790', allow_redirects=False)
+
+        with pytest.raises(ValueError):
+            loc.retrieve_label('foo', authority='foo')
+    
+        mock_response.status_code = 404
+        assert loc.retrieve_label('History of science', authority='subjects') is None
+
     # features to test for search results:
     # constructs URLs correctly for differing authorities
     # returns empty list with no results

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,14 @@ from unittest.mock import patch, Mock
 import requests
 import rdflib
 
-from loc_authorities.api import LocAPI, SRUItem, LocEntity, NameEntity, SubjectEntity, SRUResult
+from loc_authorities.api import (
+    LocAPI,
+    SRUItem,
+    LocEntity,
+    NameEntity,
+    SubjectEntity,
+    SRUResult,
+)
 
 
 FIXTURES_PATH = os.path.join(os.path.dirname(__file__), 'fixtures')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,12 +100,15 @@ class TestLocAPI(object):
 
         assert loc.retrieve_label('Franklin, Benjamin, 1706-1790') == 'n79043402'
 
-        loc.retrieve_label('Franklin, Benjamin, 1706-1790', authority="names")
-        mockrequests.get.assert_called_with('https://id.loc.gov/authorities/names/label/Franklin, Benjamin, 1706-1790', allow_redirects=False)
+        loc.retrieve_label('Franklin, Benjamin, 1706-1790', authority='names')
+        mockrequests.get.assert_called_with(
+            'https://id.loc.gov/authorities/names/label/Franklin, Benjamin, 1706-1790',
+            allow_redirects=False,
+        )
 
         with pytest.raises(ValueError):
             loc.retrieve_label('foo', authority='foo')
-    
+
         mock_response.status_code = 404
         assert loc.retrieve_label('History of science', authority='subjects') is None
 

--- a/uv.lock
+++ b/uv.lock
@@ -309,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "loc-authorities"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "rdflib" },


### PR DESCRIPTION
New features:

```api.LocEntity.retrieve_label()``` now accepts an optional argument ```authority```. This constructs the search URL to include one of the supported authority. The default option is ```None```. Passing an invalid authority should raise an error.

```api.LocEntity.retrieve_label()``` now returns ```None``` when no match is found. 

New tests were added to cover the new functionality in this function.

Once this PR is merged, we will bump the package version to 0.2.0.