### PR TITLE
Add support for complex topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ loc-authorities uses the python library rdflib to query Library of Congress enti
 
 There are no plans to support further authorities at this point in time, but pull requests for implementations of other authorities are welcome!
 
+This implementation provides dummy containers for Temporal and Complex subject entities that are valid but do not have identifiers. These implement minimal RDF with basic metadata.
+
 ## Installation
 
 Via pip into virtual environment
@@ -106,6 +108,38 @@ rdflib.term.Literal('German literature--Germany (East)', lang='en') # inherits a
 >>> subject.components
 [<loc_authorities.api.SubjectEntity object at 0x0000025AF492B810>, <loc_authorities.api.NameEntity object at 0x0000025AF492A990>]
 
+# Represent an entity with an unindexed temporal component
+>>>
+>>> from loc_authorities.api import SubjectEntity
+>>> subject = SubjectEntity('sh93000006')
+>>> subject.authoritative_label
+rdflib.term.Literal('Costa Rica--History--1986-', lang='en')
+>>> subject.components
+[<loc_authorities.api.NameEntity object at 0x000001D224378D40>, <loc_authorities.api.SubjectEntity object at 0x000001D224379430>, <loc_authorities.api.TemporalEntity object at 0x000001D22412D370>]
+>>> temporal = subject.components[2]
+>>> temporal.authoritative_label
+rdflib.term.Literal('1986-', lang='en')
+>>> temporal.instance_of
+[rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#Temporal'), rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#Authority')]
+>>> print(temporal.dataset_uriref)
+None
+
+# Represent a valid but unindexed complex entity
+>>> from loc_authorities.api import DummyComplexEntity
+# initialize the component from a list of identifiers
+# Use plain strings for unindexed temporal components
+>>> subject = DummyComplexEntity(['sh85003744', 'n79022911-781', '1733'])
+# dummy entities have many, but not all, characteristics of subject entities
+>>> subject.authoritative_label
+rdflib.term.Literal('Almanacs--Pennsylvania--1733', lang='en')
+>>> subject.instance_of
+[rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#ComplexSubject'), rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#Authority')]
+>>> subject.components
+[<loc_authorities.api.SubjectEntity object at 0x000001D2244AB050>, <loc_authorities.api.NameEntity object at 0x000001D2244AAD20>, <loc_authorities.api.TemporalEntity object at 0x000001D2244AB950>]
+# Dummy subjects take a rdflib.BNode as their identifier
+# This persists during the session, but not across sessions
+>>> subject.dataset_uriref
+rdflib.term.BNode('N13ec427732a2411299d42104094d0af3')
 ```
 
 ## Running tests

--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ Install development requirements
 ```$ pip install . --group dev```
 
 Run tests with pytest  
-```$ python -m pytest --cov --cov-report=html:calc_cov```  
+```$ python -m pytest```
 
 Run tests and produce HTML coverage report
-```$ python -m pytest 
+
+```$ python -m pytest --cov --cov-report=html:calc_cov``` 
 
 ## Build documentation
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ loc-authorities uses the python library rdflib to query Library of Congress enti
 
 There are no plans to support further authorities at this point in time, but pull requests for implementations of other authorities are welcome!
 
-This implementation provides dummy containers for Temporal and Complex subject entities that are valid but do not have identifiers. These implement minimal RDF with basic metadata.
+This implementation provides dummy containers for Temporal and Complex subject entities. Many of these components are valid but have not yet been indexed in the Library of Congress API. This means they lack URIs and cannot be validated via the Library of Congress API. These classes implement minimal RDF with basic metadata.
 
 ## Installation
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -53,9 +53,9 @@ loc_authorities provides support for querying the `"suggest" API" <https://id.lo
 
     >>> search = loc.search('Benjamin Franklin', authority='names')
     >>> search[0].uri
-    'http://id.loc.gov/authorities/names/nr91002273'
+    'http://id.loc.gov/authorities/names/n79043402'
     >>> search[0].label
-    'Joslin, Benjamin F. (Benjamin Franklin), 1796-1861'
+    'Franklin, Benjamin, 1706-1790'
 
 loc_authorities provides python classes that can represent single entities from the Linked Data Service
 
@@ -97,3 +97,34 @@ Complex topics list their components as instances of either :class:`NameEntity` 
     rdflib.term.Literal('German literature--Germany (East)', lang='en')
     >>> [type(s) for s in subject.components]
     [<class 'loc_authorities.api.SubjectEntity'>, <class 'loc_authorities.api.NameEntity'>]
+
+Complex topics can contain unindexed temporal entities. In these cases, we provide a dummy class :class:`TemporalEntity` to represent these as minimal RDF.
+
+.. doctest::
+
+    >>> from loc_authorities.api import SubjectEntity
+    >>> subject = SubjectEntity('sh93000006')
+    >>> subject.authoritative_label
+    rdflib.term.Literal('Costa Rica--History--1986-', lang='en')
+    >>> [type(s) for s in subject.components]
+    [<class 'loc_authorities.api.NameEntity'>, <class 'loc_authorities.api.SubjectEntity'>, <class 'loc_authorities.api.TemporalEntity'>]
+    >>> temporal = subject.components[2]
+    >>> temporal.authoritative_label
+    rdflib.term.Literal('1986-', lang='en')
+    >>> temporal.instance_of
+    [rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#Temporal'), rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#Authority')]
+
+For complex topics that do not currently have identifiers in the Library of Congress Linked Data Service but are nonetheless valid, the class :class:`DummyComplexEntity` is provided.
+
+.. doctest::
+
+    >>> from loc_authorities.api import DummyComplexEntity
+    >>> subject = DummyComplexEntity(['sh85003744', 'n79022911-781', '1733'])
+    >>> subject.authoritative_label
+    rdflib.term.Literal('Almanacs--Pennsylvania--1733', lang='en')
+    >>> subject.instance_of
+    [rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#ComplexSubject'), rdflib.term.URIRef('http://www.loc.gov/mads/rdf/v1#Authority')]
+    >>> [type(s) for s in subject.components]
+    [<class 'loc_authorities.api.SubjectEntity'>, <class 'loc_authorities.api.NameEntity'>, <class 'loc_authorities.api.TemporalEntity'>]
+    >>> type(subject.dataset_uriref)
+    <class 'rdflib.term.BNode'>

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -98,7 +98,7 @@ Complex topics list their components as instances of either :class:`NameEntity` 
     >>> [type(s) for s in subject.components]
     [<class 'loc_authorities.api.SubjectEntity'>, <class 'loc_authorities.api.NameEntity'>]
 
-Complex topics can contain unindexed temporal entities. In these cases, we provide a dummy class :class:`TemporalEntity` to represent these as minimal RDF.
+Complex topics can contain temporal subjects that are valid but not yet indexed by Library of Congress. These entities have no URI and cannot be validated against the Library of Congress API, nor can we access RDF provided by the API. In these cases, we provide a dummy class :class:`TemporalEntity` to represent these as minimal RDF.
 
 .. doctest::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "loc-authorities"
-version = "0.2.0"
+version = "0.3.0"
 description = "Python module for interacting with Library of Congress Linked Data Service and API endpoint"
 authors = [
     {name = "Center for Digital Scholarship at the American Philosophical Society", email = "cds@amphilsoc.org"},

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -317,6 +317,57 @@ class NameEntity(LocEntity):
         return edtf_year
 
 
+class TemporalEntity(LocEntity):
+    """Container to representa temporal subject. Most temporal subjects
+    are not indexed in LoC, so this container provides minimal RDF to capture
+    the schema. Temporal entities that are indexed should be instantiated
+    as :class:`SubjectEntity`.
+
+    Overrides :class:`LocEntity` methods to return `None` where the property
+    does not exist.
+
+    :param label: the text of the authoritative label (string)
+    """
+
+    def __init__(self, label):
+        self.label = label
+
+    @property
+    def uriref(self):
+        """LoC URI reference as instance of :class:`rdflib.URIRef`"""
+        return None
+
+    @property
+    def dataset_uriref(self):
+        """LoC URI reference that includes LCNAF dataset
+        marker as instance of :class:`rdflib.URIRef`"""
+        return None
+
+    @property
+    def rdf(self):
+        """LoC data for this entity as :class:`rdflib.Graph`"""
+        graph = rdflib.Graph()
+        bn = rdflib.BNode()
+        graph.add(
+            (bn, MADS_NS.authoritativeLabel, rdflib.Literal(self.label, lang='en'))
+        )
+        graph.add((bn, RDF.type, MADS_NS.Temporal))
+        graph.add((bn, RDF.type, MADS_NS.Authority))
+
+        return graph
+
+    @property
+    def authoritative_label(self):
+        """Authoritative entity label in English"""
+        label_literal = rdflib.Literal(self.label, lang='en')
+        return label_literal
+
+    @property
+    def scheme_membership(self):
+        """Since temporal entities are not indexed, returns None."""
+        return None
+
+
 class SubjectEntity(LocEntity):
     """Object to represent single entity from the LoC
     Subject Headings authority. Inherits :class:`LocEntity`.
@@ -350,7 +401,7 @@ class SubjectEntity(LocEntity):
                     components.append(entity)
                 else:
                     # Not covered by test suite
-                    logger.warning(f'Unrecognized schema for URI: {c}')
+                    logger.wacrning(f'Unrecognized schema for URI: {c}')
             else:
                 # Not covered by test suite
                 temp_label = self.rdf.value(c, MADS_NS.authoritativeLabel)
@@ -360,6 +411,16 @@ class SubjectEntity(LocEntity):
             return components
         else:
             return None
+
+
+class DummyComplexEntity(SubjectEntity):
+    """Container to represent a complex topic that does not
+    have a URI but contains all valid subcomponents.
+
+    :param components: URIs for subcomponents (list)
+    """
+
+    pass
 
 
 class SRUResult(object):

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -345,7 +345,7 @@ class TemporalEntity(LocEntity):
 
     @property
     def rdf(self):
-        """LoC data for this entity as :class:`rdflib.Graph`"""
+        """Basic linked data for this entity as :class:`rdflib.Graph`"""
         graph = rdflib.Graph()
         bn = rdflib.BNode()
         graph.add(
@@ -380,7 +380,7 @@ class SubjectEntity(LocEntity):
         """Components for LoC Complex subjects. If subject is
         complex, returns a list of :class:`SubjectEntity`
         and :class:`NameEntity` objects. If subject is simple,
-        returns `None`.
+        returns :class:`TemporalEntity`.
         """
         # container list for results
         components = []
@@ -416,7 +416,7 @@ class DummyComplexEntity(SubjectEntity):
     """Container to represent a complex topic that does not
     have a URI but contains all valid subcomponents.
 
-    :param components: URIs for subcomponents (list)
+    :param components: URIs or tempoal labels for subcomponents (list)
     """
 
     def __init__(self, components):
@@ -442,15 +442,16 @@ class DummyComplexEntity(SubjectEntity):
     @cached_property
     def dataset_uriref(self):
         """LoC URI reference that includes LCNAF dataset
-        marker as instance of :class:`rdflib.URIRef`
+        marker as instance of :class:`rdflib.BNode`
 
-        For queries to work, this needs to be a real URI,
-        so we use the reserved URI "http://example.org".
+        For queries to work, this is a cached property.
+        It persists during one session, but not between sessions.
         """
         return rdflib.BNode()
 
     @cached_property
     def rdf(self):
+        """Basic linked data for this entity as :class:`rdflib.Graph`"""
         graph = rdflib.Graph()
         bn = self.dataset_uriref
         graph.add((bn, MADS_NS.authoritativeLabel, self.authoritative_label))
@@ -479,6 +480,11 @@ class DummyComplexEntity(SubjectEntity):
 
     @property
     def components(self):
+        """Components for LoC Complex subjects. If subject is
+        complex, returns a list of :class:`SubjectEntity`
+        and :class:`NameEntity` objects. If subject is simple,
+        returns :class:`TemporalEntity`.
+        """
         return self.initial_components
 
     @cached_property
@@ -491,7 +497,7 @@ class DummyComplexEntity(SubjectEntity):
 
     @property
     def scheme_membership(self):
-        """Since temporal entities are not indexed, returns None."""
+        """Since entities are not indexed, returns None."""
         return None
 
 

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -401,11 +401,12 @@ class SubjectEntity(LocEntity):
                     components.append(entity)
                 else:
                     # Not covered by test suite
-                    logger.wacrning(f'Unrecognized schema for URI: {c}')
+                    logger.warning(f'Unrecognized schema for URI: {c}')
             else:
-                # Not covered by test suite
-                temp_label = self.rdf.value(c, MADS_NS.authoritativeLabel)
-                components.append(temp_label)
+                # Assume this is a temporal entity
+                label = self.rdf.value(c, MADS_NS.authoritativeLabel)
+                entity = TemporalEntity(str(label))
+                components.append(entity)
 
         if len(components) > 0:
             return components

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -381,8 +381,6 @@ class SubjectEntity(LocEntity):
         complex, returns a list of :class:`SubjectEntity`
         and :class:`NameEntity` objects. If subject is simple,
         returns `None`.
-
-        Currently does not support temporal elements.
         """
         # container list for results
         components = []
@@ -421,7 +419,80 @@ class DummyComplexEntity(SubjectEntity):
     :param components: URIs for subcomponents (list)
     """
 
-    pass
+    def __init__(self, components):
+        self.initial_components = []
+        for component in components:
+            # should not need regex since labels should not start with lowercase
+            if component.startswith('n'):
+                ent = NameEntity(component)
+                self.initial_components.append(ent)
+            elif component.startswith('sh'):
+                ent = SubjectEntity(component)
+                self.initial_components.append(ent)
+            else:
+                # assume temporal entity
+                ent = TemporalEntity(component)
+                self.initial_components.append(ent)
+
+    @property
+    def uriref(self):
+        """LoC URI reference as instance of :class:`rdflib.URIRef`"""
+        return None
+
+    @cached_property
+    def dataset_uriref(self):
+        """LoC URI reference that includes LCNAF dataset
+        marker as instance of :class:`rdflib.URIRef`
+
+        For queries to work, this needs to be a real URI,
+        so we use the reserved URI "http://example.org".
+        """
+        return rdflib.BNode()
+
+    @cached_property
+    def rdf(self):
+        graph = rdflib.Graph()
+        bn = self.dataset_uriref
+        graph.add((bn, MADS_NS.authoritativeLabel, self.authoritative_label))
+        graph.add((bn, RDF.type, MADS_NS.ComplexSubject))
+        graph.add((bn, RDF.type, MADS_NS.Authority))
+        # components
+        components_bn = rdflib.BNode()
+        graph.add((bn, MADS_NS.componentList, components_bn))
+        for n, component in enumerate(self.components):
+            if component.dataset_uriref is None:
+                uri = rdflib.BNode()
+            else:
+                uri = component.dataset_uriref
+            graph.add((components_bn, RDF.first, uri))
+            for instance in component.instance_of:
+                graph.add((uri, RDF.type, instance))
+            graph.add((uri, MADS_NS.authoritativeLabel, component.authoritative_label))
+            if n == len(self.components) - 1:
+                graph.add((components_bn, RDF.rest, RDF.nil))
+            else:
+                next_bnode = rdflib.BNode()
+                graph.add((components_bn, RDF.rest, next_bnode))
+                components_bn = next_bnode
+
+        return graph
+
+    @property
+    def components(self):
+        return self.initial_components
+
+    @cached_property
+    def authoritative_label(self):
+        """Authoritative entity label in English"""
+        labels = [c.authoritative_label for c in self.components]
+        label_string = '--'.join(labels)
+        label_literal = rdflib.Literal(label_string, lang='en')
+        return label_literal
+
+    @property
+    def scheme_membership(self):
+        """Since temporal entities are not indexed, returns None."""
+        return None
 
 
 class SRUResult(object):

--- a/tests/fixtures/sh93000006.rdf
+++ b/tests/fixtures/sh93000006.rdf
@@ -1,0 +1,92 @@
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:bf="http://id.loc.gov/ontologies/bibframe/" xmlns:bflc="http://id.loc.gov/ontologies/bflc/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:cc="http://creativecommons.org/ns#" xmlns:foaf="http://xmlns.com/foaf/0.1/">
+  <madsrdf:ComplexSubject rdf:about="http://id.loc.gov/authorities/subjects/sh93000006" xmlns:madsrdf="http://www.loc.gov/mads/rdf/v1#">
+    <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+    <madsrdf:authoritativeLabel xml:lang="en">Costa Rica--History--1986-</madsrdf:authoritativeLabel>
+    <madsrdf:componentList rdf:parseType="Collection">
+      <madsrdf:Geographic rdf:about="http://id.loc.gov/rwo/agents/n79070075">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<madsrdf:authoritativeLabel>Costa Rica</madsrdf:authoritativeLabel>
+	<madsrdf:authoritativeLabel xml:lang="ko-hang">코스타리카</madsrdf:authoritativeLabel>
+	<madsrdf:authoritativeLabel xml:lang="und-hebr">קוסטה ריקה</madsrdf:authoritativeLabel>
+	<madsrdf:authoritativeLabel xml:lang="und-cyrl">Коста-Рика</madsrdf:authoritativeLabel>
+	<madsrdf:authoritativeLabel xml:lang="und-grek">Κόστα Ρίκα</madsrdf:authoritativeLabel>
+	<madsrdf:code rdf:datatype="http://id.loc.gov/datatypes/codes/gac">nccr---</madsrdf:code>
+      </madsrdf:Geographic>
+      <madsrdf:Topic rdf:about="http://id.loc.gov/authorities/subjects/sh99005024">
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<madsrdf:authoritativeLabel xml:lang="en">History</madsrdf:authoritativeLabel>
+      </madsrdf:Topic>
+      <madsrdf:Temporal>
+	<rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	<madsrdf:authoritativeLabel xml:lang="en">1986-</madsrdf:authoritativeLabel>
+	<madsrdf:elementList rdf:parseType="Collection">
+	  <madsrdf:TemporalElement>
+	    <madsrdf:elementValue xml:lang="en">1986-</madsrdf:elementValue>
+	  </madsrdf:TemporalElement>
+	</madsrdf:elementList>
+      </madsrdf:Temporal>
+    </madsrdf:componentList>
+    <bflc:marcKey>151 0$aCosta Rica$xHistory$y1986-</bflc:marcKey>
+    <madsrdf:hasSource>
+      <madsrdf:Source>
+	<madsrdf:citationStatus>found</madsrdf:citationStatus>
+	<madsrdf:citationSource>Work cat.: 92-234625: Boggs, H. Casada con una leyenda, 1992.</madsrdf:citationSource>
+      </madsrdf:Source>
+    </madsrdf:hasSource>
+    <identifiers:lccn xmlns:identifiers="http://id.loc.gov/vocabulary/identifiers/">sh 93000006</identifiers:lccn>
+    <madsrdf:isMemberOfMADSCollection rdf:resource="http://id.loc.gov/authorities/subjects/collection_LCSHAuthorizedHeadings"/>
+    <madsrdf:isMemberOfMADSScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+    <madsrdf:isMemberOfMADSCollection rdf:resource="http://id.loc.gov/authorities/subjects/collection_LCSH_General"/>
+    <owl:sameAs rdf:resource="info:lc/authorities/sh93000006"/>
+    <owl:sameAs rdf:resource="http://id.loc.gov/authorities/sh93000006#concept"/>
+    <madsrdf:adminMetadata>
+      <ri:RecordInfo xmlns:ri="http://id.loc.gov/ontologies/RecordInfo#">
+	<ri:recordChangeDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1993-01-04T00:00:00</ri:recordChangeDate>
+	<ri:recordStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">new</ri:recordStatus>
+	<ri:recordContentSource>
+	  <madsrdf:CorporateName rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+	    <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	    <madsrdf:authoritativeLabel>United States, Library of Congress</madsrdf:authoritativeLabel>
+	    <madsrdf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</madsrdf:code>
+	    <madsrdf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</madsrdf:code>
+	    <madsrdf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</madsrdf:code>
+	  </madsrdf:CorporateName>
+	</ri:recordContentSource>
+      </ri:RecordInfo>
+    </madsrdf:adminMetadata>
+    <madsrdf:adminMetadata>
+      <ri:RecordInfo xmlns:ri="http://id.loc.gov/ontologies/RecordInfo#">
+	<ri:recordChangeDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1993-02-04T14:34:02</ri:recordChangeDate>
+	<ri:recordStatus rdf:datatype="http://www.w3.org/2001/XMLSchema#string">revised</ri:recordStatus>
+	<ri:recordContentSource>
+	  <madsrdf:CorporateName rdf:about="http://id.loc.gov/vocabulary/organizations/dlc">
+	    <rdf:type rdf:resource="http://www.loc.gov/mads/rdf/v1#Authority"/>
+	    <madsrdf:authoritativeLabel>United States, Library of Congress</madsrdf:authoritativeLabel>
+	    <madsrdf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/code">DLC</madsrdf:code>
+	    <madsrdf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/normalized">dlc</madsrdf:code>
+	    <madsrdf:code rdf:datatype="http://id.loc.gov/datatypes/orgs/iso15511">US-dlc</madsrdf:code>
+	  </madsrdf:CorporateName>
+	</ri:recordContentSource>
+      </ri:RecordInfo>
+    </madsrdf:adminMetadata>
+    <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+    <skos:prefLabel xml:lang="en">Costa Rica--History--1986-</skos:prefLabel>
+    <skos:inScheme rdf:resource="http://id.loc.gov/authorities/subjects"/>
+    <skos:changeNote>
+      <cs:ChangeSet xmlns:cs="http://purl.org/vocab/changeset/schema#">
+	<cs:subjectOfChange rdf:resource="http://id.loc.gov/authorities/subjects/sh93000006"/>
+	<cs:creatorName>United States, Library of CongressDLCdlcUS-dlc</cs:creatorName>
+	<cs:createdDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1993-01-04T00:00:00</cs:createdDate>
+	<cs:changeReason rdf:datatype="http://www.w3.org/2001/XMLSchema#string">new</cs:changeReason>
+      </cs:ChangeSet>
+    </skos:changeNote>
+    <skos:changeNote>
+      <cs:ChangeSet xmlns:cs="http://purl.org/vocab/changeset/schema#">
+	<cs:subjectOfChange rdf:resource="http://id.loc.gov/authorities/subjects/sh93000006"/>
+	<cs:creatorName>United States, Library of CongressDLCdlcUS-dlc</cs:creatorName>
+	<cs:createdDate rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">1993-02-04T14:34:02</cs:createdDate>
+	<cs:changeReason rdf:datatype="http://www.w3.org/2001/XMLSchema#string">revised</cs:changeReason>
+      </cs:ChangeSet>
+    </skos:changeNote>
+  </madsrdf:ComplexSubject>
+</rdf:RDF>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -351,6 +351,25 @@ class TestSubjectEntity(object):
         with patch.object(SubjectEntity, 'rdf', new=test_rdf):
             assert ent.components is None
 
+    def test_complex_entity_with_time(self):
+        # Complex entities can have time components that do not have
+        # URIs
+
+        rdf_fixture = os.path.join(FIXTURES_PATH, 'sh93000006.rdf')
+
+        ent = SubjectEntity('sh93000006')
+        test_rdf = rdflib.Graph()
+        test_rdf.parse(rdf_fixture)
+
+        with patch.object(SubjectEntity, 'rdf', new=test_rdf):
+            assert len(ent.components) == 3
+            names = [isinstance(c, NameEntity) for c in ent.components]
+            subjects = [isinstance(c, SubjectEntity) for c in ent.components]
+            temporal = [isinstance(c, TemporalEntity) for c in ent.components]
+            assert names.count(True) == 1
+            assert subjects.count(True) == 1
+            assert temporal.count(True) == 1
+
 
 def test_sru_result():
     sru_fixture = os.path.join(FIXTURES_PATH, 'sru_search.json')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,6 +13,7 @@ from loc_authorities.api import (
     NameEntity,
     TemporalEntity,
     SubjectEntity,
+    DummyComplexEntity,
     SRUResult,
 )
 
@@ -369,6 +370,103 @@ class TestSubjectEntity(object):
             assert names.count(True) == 1
             assert subjects.count(True) == 1
             assert temporal.count(True) == 1
+
+
+class TestDummyComplexEntity(object):
+    component_ids = [
+        'sh85048256',
+        'n79006404-781',
+        'sh99005024',
+        'sh2002012474',
+        'sh2002012010',
+    ]
+    ent = DummyComplexEntity(component_ids)
+
+    def test_dummy_complex_entity(self):
+        """Assert possible to make representation for following label:
+        Finance--France--History--18th century--Sources
+        """
+        target_label = rdflib.Literal(
+            'Finance--France--History--18th century--Sources', lang='en'
+        )
+        assert self.ent.authoritative_label == target_label
+
+    def test_null_properties(self):
+        assert self.ent.uriref is None
+        assert self.ent.scheme_membership is None
+
+    def test_dataset_uriref(self):
+        assert isinstance(self.ent.dataset_uriref, rdflib.BNode)
+
+    def test_rdf(self):
+        # since we construct RDF ourselves, there should never be more than one label
+        label = list(
+            self.ent.rdf.objects(
+                self.ent.dataset_uriref,
+                rdflib.URIRef('http://www.loc.gov/mads/rdf/v1#authoritativeLabel'),
+            )
+        )[0]
+        assert label == self.ent.authoritative_label
+
+        # test components
+        component_uris = []
+        c_bnode = self.ent.rdf.value(
+            self.ent.dataset_uriref,
+            rdflib.URIRef('http://www.loc.gov/mads/rdf/v1#componentList'),
+        )
+        components_rdf = rdflib.collection.Collection(self.ent.rdf, c_bnode)
+        for c in components_rdf:
+            component_uris.append(c)
+        target_labels = sorted(
+            [
+                rdflib.URIRef('http://id.loc.gov/authorities/subjects/sh85048256'),
+                rdflib.URIRef('http://id.loc.gov/authorities/names/n79006404-781'),
+                rdflib.URIRef('http://id.loc.gov/authorities/subjects/sh99005024'),
+                rdflib.URIRef('http://id.loc.gov/authorities/subjects/sh2002012474'),
+                rdflib.URIRef('http://id.loc.gov/authorities/subjects/sh2002012010'),
+            ]
+        )
+        assert target_labels == sorted(component_uris)
+
+    def test_instance_of(self):
+        # instances is formed from ent.rdf, so this is implicitly a test for
+        # whether the rdf is correctly parsed
+        test_instances = [
+            'http://www.loc.gov/mads/rdf/v1#ComplexSubject',
+            'http://www.loc.gov/mads/rdf/v1#Authority',
+        ]
+        instances = [str(i) for i in self.ent.instance_of]
+        assert set(test_instances) == set(instances)
+
+    def test_dummy_complex_entity_with_temporal_element(self):
+        """Assert non-indexed temporal entities are represented"""
+        component_ids = ['sh85003744', 'n79022911-781', '1733']
+        dummy_entity = DummyComplexEntity(component_ids)
+        target_label = rdflib.Literal('Almanacs--Pennsylvania--1733', lang='en')
+        assert dummy_entity.authoritative_label == target_label
+
+        component_uris = []
+        c_bnode = dummy_entity.rdf.value(
+            dummy_entity.dataset_uriref,
+            rdflib.URIRef('http://www.loc.gov/mads/rdf/v1#componentList'),
+        )
+        components_rdf = rdflib.collection.Collection(dummy_entity.rdf, c_bnode)
+        for c in components_rdf:
+            component_uris.append(c)
+        component_labels = []
+        for c in component_uris:
+            label = dummy_entity.rdf.value(
+                c, rdflib.URIRef('http://www.loc.gov/mads/rdf/v1#authoritativeLabel')
+            )
+            component_labels.append(label)
+        target_labels = sorted(
+            [
+                rdflib.Literal('Almanacs', lang='en'),
+                rdflib.Literal('Pennsylvania'),
+                rdflib.Literal('1733', lang='en'),
+            ]
+        )
+        assert target_labels == sorted(component_labels)
 
 
 def test_sru_result():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,6 +11,7 @@ from loc_authorities.api import (
     SRUItem,
     LocEntity,
     NameEntity,
+    TemporalEntity,
     SubjectEntity,
     SRUResult,
 )
@@ -298,6 +299,29 @@ class TestNameEntity(object):
         # test uncertainty markers in EDTF
         assert NameEntity.year_from_edtf('1847?') == 1847
         assert NameEntity.year_from_edtf('0213~') == 213
+
+
+class TestTemporalEntity(object):
+    label = '1986-'
+    ent = TemporalEntity(label)
+
+    def test_authoritative_label(self):
+        assert str(self.ent.authoritative_label) == '1986-'
+
+    def test_null_properties(self):
+        assert self.ent.uriref is None
+        assert self.ent.dataset_uriref is None
+        assert self.ent.scheme_membership is None
+
+    def test_instance_of(self):
+        # instances is formed from ent.rdf, so this is implicitly a test for
+        # whether the rdf is correctly parsed
+        test_instances = [
+            'http://www.loc.gov/mads/rdf/v1#Temporal',
+            'http://www.loc.gov/mads/rdf/v1#Authority',
+        ]
+        instances = [str(i) for i in self.ent.instance_of]
+        assert set(test_instances) == set(instances)
 
 
 class TestSubjectEntity(object):


### PR DESCRIPTION
This PR adds two new classes to ```loc_authorities.api```:

- ```TemporalEntity```
- ```DummyComplexEntity```

When you initialize a ```SubjectEntity``` that includes a temporal component that does not have a URI, the string value will be passed to ```TemporalEntity```. This implements minimal RDF for the object, allowing it to be represented in a linked data environment. There is probably a lot that could be added to the RDF, but it is functional.

A ```DummyComplexEntity``` is initialized from a list of identifiers. This can include plain labels for unindexed temporal entities (e.g. "1733") but should not for entities that have an identifier (e.g. use "sh2002012474", not "18th century"). To initialize a representation for "Almanacs--Pennsylvania--1733", you would call

```subject = DummyComplexEntity(['sh85003744', 'n79022911-781', '1733']```

This fetches the subcomponents from the Library of Congress API and provides convenience methods for accessing some of the subjects properties. It also provides a minimal RDF implementation that is almost certainly severely lacking.

A ```DummyComplexEntity``` gets an ```rdflib.BNode``` for its URI. This is cached in the session to allow for querying the RDF, but the identifier will not (and should not) persist between sessions.

For review:

- [ ] Run tests
- [ ] Test out the new methods in Python API
- [ ] Look at the documentation changes to see if they are sufficient