### PR TITLE
Bugfix: escape labels before retrieving

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,7 @@
 project = 'loc-authorities'
 copyright = '2025, CDS @ APS'
 author = 'CDS @ APS'
-release = '0.1'
+release = '0.3.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "loc-authorities"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python module for interacting with Library of Congress Linked Data Service and API endpoint"
 authors = [
     {name = "Center for Digital Scholarship at the American Philosophical Society", email = "cds@amphilsoc.org"},

--- a/src/loc_authorities/api.py
+++ b/src/loc_authorities/api.py
@@ -1,5 +1,5 @@
 from rdflib import Namespace
-from urllib.parse import urljoin
+from urllib.parse import urljoin, quote
 from functools import cached_property
 from typing import Literal
 
@@ -171,7 +171,8 @@ class LocAPI(object):
                 - names
                 - genreForms
                 """)
-        query_url = urljoin(base_url, label)
+        escaped_label = quote(label)
+        query_url = urljoin(base_url, escaped_label)
         response = requests.get(query_url, allow_redirects=False)
         # successful query should return a redirect
         if response.status_code == 302:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -109,19 +109,23 @@ class TestLocAPI(object):
         )
 
         escape_headers = {
-            'location': 'https://id.loc.gov/authorities/names/n79072794',
-            'x-uri': 'http://id.loc.gov/authorities/names/n79072794',
-            'x-preflabel': 'Sequoyah, 1770?-1843',
+            'location': 'https://id.loc.gov/authorities/names/no2013089075',
+            'x-uri': 'http://id.loc.gov/authorities/names/no2013089075',
+            'x-preflabel': 'Simon, Claude-François, 1710?-1767',
         }
 
         mock_response.headers = escape_headers
 
         assert (
-            loc.retrieve_label('Sequoyah, 1770?-1843', authority='names') == 'n79072794'
+            loc.retrieve_label('Simon, Claude-François, 1710?-1767', authority='names')
+            == 'no2013089075'
         )
-        loc.retrieve_label('Sequoyah, 1770?-1843', authority='names')
+        loc.retrieve_label('Simon, Claude-François, 1710?-1767', authority='names')
         mockrequests.get.assert_called_with(
-            'https://id.loc.gov/authorities/names/label/Sequoyah%2C%201770%3F-1843',
+            (
+                'https://id.loc.gov/authorities/names/label/Simon%2C%20Claude-Fran%C3%A7ois'
+                '%2C%201710%3F-1767'
+            ),
             allow_redirects=False,
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -104,7 +104,22 @@ class TestLocAPI(object):
 
         loc.retrieve_label('Franklin, Benjamin, 1706-1790', authority='names')
         mockrequests.get.assert_called_with(
-            'https://id.loc.gov/authorities/names/label/Franklin, Benjamin, 1706-1790',
+            'https://id.loc.gov/authorities/names/label/Franklin%2C%20Benjamin%2C%201706-1790',
+            allow_redirects=False,
+        )
+
+        escape_headers = {
+            'location': 'https://id.loc.gov/authorities/names/n79072794',
+            'x-uri': 'http://id.loc.gov/authorities/names/n79072794',
+            'x-preflabel': 'Sequoyah, 1770?-1843'
+        }
+
+        mock_response.headers = escape_headers
+
+        assert loc.retrieve_label('Sequoyah, 1770?-1843', authority='names') == 'n79072794'
+        loc.retrieve_label('Sequoyah, 1770?-1843', authority='names')
+        mockrequests.get.assert_called_with(
+            'https://id.loc.gov/authorities/names/label/Sequoyah%2C%201770%3F-1843',
             allow_redirects=False,
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -111,12 +111,14 @@ class TestLocAPI(object):
         escape_headers = {
             'location': 'https://id.loc.gov/authorities/names/n79072794',
             'x-uri': 'http://id.loc.gov/authorities/names/n79072794',
-            'x-preflabel': 'Sequoyah, 1770?-1843'
+            'x-preflabel': 'Sequoyah, 1770?-1843',
         }
 
         mock_response.headers = escape_headers
 
-        assert loc.retrieve_label('Sequoyah, 1770?-1843', authority='names') == 'n79072794'
+        assert (
+            loc.retrieve_label('Sequoyah, 1770?-1843', authority='names') == 'n79072794'
+        )
         loc.retrieve_label('Sequoyah, 1770?-1843', authority='names')
         mockrequests.get.assert_called_with(
             'https://id.loc.gov/authorities/names/label/Sequoyah%2C%201770%3F-1843',

--- a/uv.lock
+++ b/uv.lock
@@ -309,7 +309,7 @@ wheels = [
 
 [[package]]
 name = "loc-authorities"
-version = "0.2.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "rdflib" },


### PR DESCRIPTION
This changes the behavior of `LocAPI.retrieve_label()` to perform percent-encoding on the query string before passing it to the request. This should allow retrieval of labels that include reserved characters (`?`, `&` etc.) as well as resolve any issues with non-ASCII characters.

Note this does not resolve any issues inherent in the LoC API itself. For instance, it seems that the API often fails to retrieve a label when no authority is passed.